### PR TITLE
Add Cargo Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /piston
 /life
+target/
 
 .*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - sudo apt-get install -qq libportaudio-dev libsdl2-dev libsdl2-mixer-dev libsdl2-ttf-dev
 
 script:
-  - make
+  - cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+
+name = "game-of-life"
+version = "0.0.0"
+authors = [
+    "Arcterus <arcterus@mail.com>",
+    "indiv0 <contact@nikitapek.in>"]
+
+[[bin]]
+
+name = "game-of-life"
+path = "./src/life.rs"
+
+[dependencies.piston]
+
+git = "https://github.com/PistonDevelopers/piston"
+
+[dependencies.graphics]
+
+git = "https://github.com/PistonDevelopers/rust-graphics"
+
+[dependencies.sdl2_game_window]
+
+git = "https://github.com/PistonDevelopers/sdl2_game_window"
+
+[dependencies.opengl_graphics]
+
+git = "https://github.com/PistonDevelopers/opengl_graphics"
+

--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ Build Instructions
 ------------------
 
 ```
-make
+cargo build
 ```
 
 Game Instructions
 -----------------
 
 When the game starts up, you click on areas with your mouse where you'd like
-cells to appear.  When you've finished making cells, hit either the ```return```
-key or the ```p``` key to watch the game run.  Both of these keys may be used
-to pause the game.  If you'd like to restart the game, press ```r```.
+cells to appear.  When you've finished making cells, hit either the `return`
+key or the `p` key to watch the game run.  Both of these keys may be used
+to pause the game.  If you'd like to restart the game, press `r`.
 
 Contribute
 ----------
@@ -31,10 +31,11 @@ Credits
 
 * Arcterus (this entire project)
 * MagentaCompanion (the original thndr of making the Game of Life in Java)
+* Indiv0 (updates and Cargo support)
 
 License
 -------
 
 Copyright (C) 2014 by Arcterus.  
-This project is licensed under the MPL v2.0.  See ```LICENSE``` for more
+This project is licensed under the MPL v2.0.  See `LICENSE` for more
 details.


### PR DESCRIPTION
Add Cargo support for building (instead of `make` and submodules).

Additionally updated README for Cargo instructions and minor formatting fixes.
